### PR TITLE
Swap image tag format to be compat with our standard one

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,12 +53,12 @@ jobs:
       - name: build
         run: yarn build
 
-      - id: get-short-sha
-        uses: actions/github-script@0.9.0
-        with:
-          script: |
-            const shortSha = context.sha.substring(0, 7)
-            core.setOutput('shortSha', shortSha)
+      - name: Generate build ID
+        id: prep
+        run: |
+          sha=${GITHUB_SHA::8}
+          ts=$(date +%s)
+          echo "::set-output name=BUILD_ID::${sha}-${ts}"
 
       - name: 'Build and push image'
         uses: azure/docker-login@v1
@@ -68,13 +68,13 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
       - run: |
           yarn workspace backend build-image
-          docker tag backstage:latest ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:pr-${{github.event.number}}-${{ steps.get-short-sha.outputs.shortSha }}-${{ github.run_number }}
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:pr-${{github.event.number}}-${{ steps.get-short-sha.outputs.shortSha }}-${{ github.run_number }}
+          docker tag backstage:latest ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:pr-${{ steps.prep.outputs.BUILD_ID }}
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:pr-${{ steps.prep.outputs.BUILD_ID }}
         if: startsWith(github.ref, 'refs/pull')
       - run: |
           yarn workspace backend build-image
-          docker tag backstage:latest ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:prod-${{ steps.get-short-sha.outputs.shortSha }}-${{ github.run_number }}
-          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:prod-${{ steps.get-short-sha.outputs.shortSha }}-${{ github.run_number }}
+          docker tag backstage:latest ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:prod-${{ steps.prep.outputs.BUILD_ID }}
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/backstage/backend:prod-${{ steps.prep.outputs.BUILD_ID }}
         if: github.ref == 'refs/heads/master'
 
 


### PR DESCRIPTION
using https://fluxcd.io/docs/guides/sortable-image-tags/#example-of-a-build-process-with-timestamp-tagging

previously https://fluxcd.io/docs/guides/sortable-image-tags/#alternative-example-utilizing-githubrun_number

Our standard image policy should work with this one now without needing to override